### PR TITLE
fix volume error in examples and refactor diagram generators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ tests = [
     "pytest>=8.4.1",
     "tabulate>=0.9.0",
 ]
+example = [
+    "damask==3.0.2",
+]
 
 [tool.pyright]
 typeCheckingMode = "off"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthetmic"
-version = "0.2.3"
+version = "0.2.4"
 description = "A Python package for generating synthetic Laguerre polycrystalline microstructures"
 readme = "README.md"
 authors = [

--- a/src/synthetmic/data/paper.py
+++ b/src/synthetmic/data/paper.py
@@ -87,14 +87,15 @@ def create_example4_data(initializer: str, is_periodic: bool) -> SynthetMicData:
     N2 = 200
 
     domain = np.array([[0, 3], [0, 2]])
+    n_grains = N1 + N2
 
     match initializer:
         case Initializer.RANDOM:
-            y = np.zeros(N1 + N2)
+            y = np.zeros(n_grains)
             y[:N1] = AREA_FRAC
             y[N1:] = 20 * AREA_FRAC
 
-            X = sample_random_seeds(domain, N1 + N2)
+            X = sample_random_seeds(domain, n_grains)
 
         case Initializer.BANDED:
             subdomains = create_subdomains(domain=domain, n_subdomains=7)
@@ -105,8 +106,12 @@ def create_example4_data(initializer: str, is_periodic: bool) -> SynthetMicData:
                 n_points_large=math.ceil(N2 / 4),
                 volume_frac=AREA_FRAC,
             )
-            X = np.array(X)[: N1 + N2]
-            y = np.array(y)[: N1 + N2]
+
+            X = np.array(X)[:n_grains]
+            y = np.array(y)[:n_grains]
+
+            # Add residuals to areas so that their sum equals to domain area.
+            y += (np.prod(domain[:, 1] - domain[:, 0]) - y.sum()) / n_grains
 
         case Initializer.CLUSTERED:
             X = []

--- a/src/synthetmic/data/utils.py
+++ b/src/synthetmic/data/utils.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SynthetMicData:
     seeds: np.ndarray
     volumes: np.ndarray | None

--- a/src/synthetmic/generate.py
+++ b/src/synthetmic/generate.py
@@ -17,6 +17,9 @@ from synthetmic.utils import (
 
 
 class DiagramGenerator(ABC):
+    _pd: PowerDiagram | None = None
+    _space_dim: int | None
+
     def __init__(self, verbose: bool) -> None:
         self.verbose = verbose
 
@@ -25,67 +28,100 @@ class DiagramGenerator(ABC):
         pass
 
     @abstractmethod
-    def get_fitted_volumes(self) -> np.ndarray:
-        pass
-
-    @abstractmethod
-    def get_mesh(self) -> pv.PolyData | pv.UnstructuredGrid:
-        pass
-
-    @abstractmethod
-    def get_positions(self) -> np.ndarray:
-        pass
-
-    @abstractmethod
-    def get_centroids(self) -> np.ndarray:
-        pass
-
-    @abstractmethod
-    def get_vertices(self) -> dict[int, list]:
-        pass
-
-    @abstractmethod
-    def get_weights(self) -> np.ndarray:
-        pass
-
-    @abstractmethod
-    def diagram_to_vtk(self, filename: str | Path) -> None:
-        pass
-
-    @abstractmethod
     def get_params(self) -> dict[str, Any]:
         pass
 
-    def _print_msg(self, msg: str) -> None:
-        if self.verbose:
-            print(msg)
+    @property
+    def pd_(self):
+        if self._pd is None:
+            self._raise_not_fitted_error()
 
-        return None
+        return self._pd
 
-    def _get_mesh(self, pd: PowerDiagram) -> pv.UnstructuredGrid | pv.PolyData:
+    @property
+    def space_dim_(self):
+        if self._space_dim is None:
+            self._raise_not_fitted_error()
+
+        return self._space_dim
+
+    def get_fitted_volumes(self) -> np.ndarray:
+        """
+        Get the computed diagram cell volumes.
+        """
+        return self.pd_.integrals()
+
+    def get_mesh(self) -> pv.UnstructuredGrid | pv.PolyData:
+        """
+        Get the underlying diagram mesh as a pyvista PolyData or UnstructuredGrid data object.
+        """
+
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".vtk", delete=True
         ) as tmp_file:
             filename = tmp_file.name
 
-            pd.display_vtk(filename, points=None, centroids=None)
+            self.pd_.display_vtk(filename, points=None, centroids=None)
 
             mesh = pv.read(filename)
 
         return mesh
 
-    def _get_vertices(self, pd: PowerDiagram, space_dim: int) -> dict[int, list]:
+    def get_positions(self) -> np.ndarray:
+        """
+        Get the final positions of seeds.
+        """
+
+        return self.pd_.get_positions()
+
+    def get_centroids(self) -> np.ndarray:
+        """
+        Get the centroids of the cells in the Voronoi diagram.
+        """
+
+        return self.pd_.centroids()
+
+    def get_vertices(self) -> dict[int, list]:
+        """
+        Get the vertices of cells in the diagram.
+
+        Return
+        ------
+        A dictionary with keys as cell ids and values as the
+        corresponding vertices.
+
+        In 2D, the format looks like this:
+
+        {
+            0: [v_1, v_2, ...],
+            ...
+            n-1: [v_1, v_2, ...],
+
+        }
+        where n is the number of cells or grains.
+
+        In 3D, the format looks like this:
+
+        {
+            0: [[v_1, v_2, ...], [v_1, v_2, ...], ...],
+            ...
+            n-1: [[v_1, v_2, ...], [v_1, v_2, ...], ...],
+
+        }
+        where n is the number of cells or grains. Note that the inner
+        list of vertices for each cell corresponds to the face vertices.
+        """
         res = {}
 
-        if space_dim == 2:
-            offsets, coords = pd.cell_polyhedra()
+        if self.space_dim_ == 2:
+            offsets, coords = self.pd_.cell_polyhedra()
 
             for i in range(len(offsets) - 1):
                 s, e = offsets[i : i + 2]
                 res[i] = coords[s:e].tolist()
 
-        elif space_dim == 3:
-            offsets_polyhedra, offsets_polygon, coords = pd.cell_polyhedra()
+        elif self.space_dim_ == 3:
+            offsets_polyhedra, offsets_polygon, coords = self.pd_.cell_polyhedra()
 
             for i in range(len(offsets_polyhedra) - 1):
                 s1, e1 = offsets_polyhedra[i : i + 2]
@@ -103,6 +139,39 @@ class DiagramGenerator(ABC):
                 res[i] = cell_vertices
 
         return res
+
+    def get_weights(self) -> np.ndarray:
+        """
+        Get the weights of the diagram.
+        """
+
+        return self.pd_.get_weights()
+
+    def diagram_to_vtk(self, filename: str | Path) -> None:
+        """
+        Write the generated diagram to .vkt file; filename must ends with .vtk.
+        """
+
+        self.pd_.display_vtk(filename=filename, points=False, centroids=False)
+
+        return None
+
+    def _set_pd(self, pd: PowerDiagram) -> None:
+        self._pd = pd
+
+        return None
+
+    def _print_msg(self, msg: str) -> None:
+        if self.verbose:
+            print(msg)
+
+        return None
+
+    def _raise_not_fitted_error(self) -> None:
+        raise NotFittedError(
+            f"This {self.__class__.__name__} instance is not fitted yet. "
+            f"Call 'fit' with appropriate arguments before using this instance."
+        )
 
 
 class VoronoiDiagramGenerator(DiagramGenerator):
@@ -123,26 +192,18 @@ class VoronoiDiagramGenerator(DiagramGenerator):
         n_iter: int = 5,
         damp_param: float = 1.0,
         verbose: bool = True,
-    ):
+    ) -> None:
+        validate_generator_params(
+            tol=None,
+            n_iter=n_iter,
+            damp_param=damp_param,
+            verbose=verbose,
+        )
+
         super().__init__(verbose)
 
         self.n_iter = n_iter
         self.damp_param = damp_param
-
-        self.pd_: PowerDiagram | None = None
-        self.space_dim_: int | None = None
-
-    def _update_pd(self, pd: PowerDiagram) -> None:
-        self.pd_ = pd
-
-    def _ensure_fitted(self) -> NotFittedError | None:
-        if self.pd_ is None:
-            raise NotFittedError(
-                f"This {self.__class__.__name__} instance is not fitted yet. "
-                f"Call 'fit' with appropriate arguments before using this generator."
-            )
-
-        return None
 
     def fit(
         self,
@@ -171,13 +232,6 @@ class VoronoiDiagramGenerator(DiagramGenerator):
         synthetmic.generate.VoronoiDiagramGenerator
         """
 
-        validate_generator_params(
-            tol=None,
-            n_iter=self.n_iter,
-            damp_param=self.damp_param,
-            verbose=self.verbose,
-        )
-
         validate_fit_args(
             seeds=seeds,
             volumes=None,
@@ -187,8 +241,10 @@ class VoronoiDiagramGenerator(DiagramGenerator):
         )
 
         omega, lens = build_domain(domain=domain, periodic=periodic)
+
         num_grains, space_dim = seeds.shape
-        self.space_dim_ = space_dim
+        self._space_dim = space_dim
+
         weights = np.zeros(num_grains)
         pd = PowerDiagram(positions=seeds, weights=weights, domain=omega)
 
@@ -196,109 +252,19 @@ class VoronoiDiagramGenerator(DiagramGenerator):
             add_replicants(obj=pd, periodic=periodic, domain_lens=lens)
 
         if self.n_iter == 0:
-            self._update_pd(pd)
+            self._set_pd(pd)
             return self
 
         for k in range(self.n_iter):
             seeds = (1 - self.damp_param) * seeds + self.damp_param * pd.centroids()
             pd.set_positions(seeds)
 
-            self._update_pd(pd)
+            self._set_pd(pd)
             self._print_msg(
                 f"iteration: {k + 1}/{self.n_iter}, norm of change in positions: {np.linalg.norm(pd.centroids() - seeds)}",
             )
 
         return self
-
-    def get_fitted_volumes(self) -> np.ndarray:
-        """
-        Get the computed Voronoi cell volumes.
-        """
-        self._ensure_fitted()
-
-        return self.pd_.integrals()
-
-    def get_mesh(self) -> pv.PolyData | pv.UnstructuredGrid:
-        """
-        Get the underlying Voronoi mesh as a pyvista PolyData or UnstructuredGrid data object.
-        """
-
-        self._ensure_fitted()
-
-        return self._get_mesh(self.pd_)
-
-    def get_positions(self) -> np.ndarray:
-        """
-        Get the final positions of seeds.
-        """
-
-        self._ensure_fitted()
-
-        return self.pd_.get_positions()
-
-    def get_centroids(self) -> np.ndarray:
-        """
-        Get the centroids of the cells in the Voronoi diagram.
-        """
-
-        self._ensure_fitted()
-
-        return self.pd_.centroids()
-
-    def get_vertices(self) -> dict[int, list]:
-        """
-        Get the vertices of the cells in the Voronoi diagram.
-
-        Return
-        ------
-        A dictionary with keys as cell ids and values as the
-        corresponding vertices.
-
-        In 2D, the format looks like this:
-
-        {
-            0: [v_1, v_2, ...],
-            ...
-            n-1: [v_1, v_2, ...],
-
-        }
-        where n is the number of cells or grains.
-
-        In 3D, the format looks like this:
-
-        {
-            0: [[v_1, v_2, ...], [v_1, v_2, ...], ...],
-            ...
-            n-1: [[v_1, v_2, ...], [v_1, v_2, ...], ...],
-
-        }
-        where n is the number of cells or grains. Note that the inner
-        list of vertices for each cell corresponds to the face vertices.
-        """
-
-        self._ensure_fitted()
-
-        return self._get_vertices(pd=self.pd_, space_dim=self.space_dim_)
-
-    def get_weights(self) -> np.ndarray:
-        """
-        Get the weights of the Voronoi diagram.
-        """
-
-        self._ensure_fitted()
-
-        return self.pd_.get_weights()
-
-    def diagram_to_vtk(self, filename: str | Path) -> None:
-        """
-        Write the generated diagram to .vkt file; filename must ends with .vtk.
-        """
-
-        self._ensure_fitted()
-
-        self.pd_.display_vtk(filename=filename, points=False, centroids=False)
-
-        return None
 
     def get_params(self) -> dict[str, Any]:
         """
@@ -334,35 +300,34 @@ class LaguerreDiagramGenerator(DiagramGenerator):
         damp_param: float = 1.0,
         verbose: bool = True,
     ):
+        validate_generator_params(
+            tol=tol,
+            n_iter=n_iter,
+            damp_param=damp_param,
+            verbose=verbose,
+        )
+
         super().__init__(verbose)
 
         self.tol = tol
         self.n_iter = n_iter
         self.damp_param = damp_param
 
-        self.space_dim_: int | None = None
         self.optimal_transport_: OptimalTransport | None = None
         self.max_percentage_error_: float | None = None
         self.mean_percentage_error_: float | None = None
 
-    def _update_optimal_transport(self, optimal_transport: OptimalTransport) -> None:
+    def _set_optimal_transport(self, optimal_transport: OptimalTransport) -> None:
         self.optimal_transport_ = optimal_transport
 
-    def _update_errors(self, y: np.ndarray) -> None:
+        return None
+
+    def _set_errors(self, y: np.ndarray) -> None:
         percentage_errors = np.array(
             100.0 * np.abs(self.optimal_transport_.pd.integrals() - y) / y
         )
         self.max_percentage_error_ = percentage_errors.max()
         self.mean_percentage_error_ = percentage_errors.mean()
-
-    def _ensure_fitted(self) -> NotFittedError | None:
-        if self.optimal_transport_ is None:
-            raise NotFittedError(
-                f"This {self.__class__.__name__} instance is not fitted yet. "
-                f"Call 'fit' with appropriate arguments before using this estimator."
-            )
-
-        return None
 
     def fit(
         self,
@@ -404,13 +369,6 @@ class LaguerreDiagramGenerator(DiagramGenerator):
         synthetmic.generate.LeguerreDiagramGenerator
         """
 
-        validate_generator_params(
-            tol=self.tol,
-            n_iter=self.n_iter,
-            damp_param=self.damp_param,
-            verbose=self.verbose,
-        )
-
         validate_fit_args(
             seeds=seeds,
             volumes=volumes,
@@ -419,7 +377,7 @@ class LaguerreDiagramGenerator(DiagramGenerator):
             init_weights=init_weights,
         )
 
-        self.space_dim_ = domain.shape[0]
+        self._space_dim = domain.shape[0]
 
         # Turn the relative percentage error into an absolute error tolerance
         # by using the smallest volume
@@ -447,8 +405,9 @@ class LaguerreDiagramGenerator(DiagramGenerator):
         if self.n_iter == 0:
             optimal_transport.adjust_weights()
 
-            self._update_optimal_transport(optimal_transport=optimal_transport)
-            self._update_errors(y=volumes)
+            self._set_optimal_transport(optimal_transport=optimal_transport)
+            self._set_pd(optimal_transport.pd)
+            self._set_errors(y=volumes)
 
             return self
 
@@ -468,12 +427,12 @@ class LaguerreDiagramGenerator(DiagramGenerator):
             if np.min(m) > MIN_VOL_TOL:
                 optimal_transport.adjust_weights()
             else:
-                self._print_msg("Resetting weights to init_weights")
                 optimal_transport.set_weights(init_weights)
                 optimal_transport.adjust_weights()
 
-            self._update_optimal_transport(optimal_transport)
-            self._update_errors(volumes)
+            self._set_optimal_transport(optimal_transport)
+            self._set_pd(optimal_transport.pd)
+            self._set_errors(volumes)
 
             self._print_msg(
                 f"iteration: {k + 1}/{self.n_iter}, max_percentage_error: {self.max_percentage_error_:.4f}%, "
@@ -481,100 +440,6 @@ class LaguerreDiagramGenerator(DiagramGenerator):
             )
 
         return self
-
-    def get_fitted_volumes(self) -> np.ndarray:
-        """
-        Get the fitted volumes after fitting generator.
-        """
-        self._ensure_fitted()
-
-        return self.optimal_transport_.pd.integrals()
-
-    def get_mesh(self) -> pv.PolyData | pv.UnstructuredGrid:
-        """
-        Get the underlying mesh as a pyvista PolyData or UnstructuredGrid data object.
-        """
-
-        self._ensure_fitted()
-
-        return self._get_mesh(self.optimal_transport_.pd)
-
-    def get_positions(self) -> np.ndarray:
-        """
-        Get the final positions of initial seeds used for generating the laguerre diagram.
-        """
-
-        self._ensure_fitted()
-
-        return self.optimal_transport_.pd.get_positions()
-
-    def get_centroids(self) -> np.ndarray:
-        """
-        Get the centroids of the cells in the laguerre diagram.
-        """
-
-        self._ensure_fitted()
-
-        return self.optimal_transport_.pd.centroids()
-
-    def get_vertices(self) -> dict[int, list]:
-        """
-        Get the vertices of the cells in the laguerre diagram.
-
-        Return
-        ------
-        A dictionary with keys as cell ids and values as the
-        corresponding vertices.
-
-        In 2D, the format looks like this:
-
-        {
-            0: [v_1, v_2, ...],
-            ...
-            n-1: [v_1, v_2, ...],
-
-        }
-        where n is the number of cells or grains.
-
-        In 3D, the format looks like this:
-
-        {
-            0: [[v_1, v_2, ...], [v_1, v_2, ...], ...],
-            ...
-            n-1: [[v_1, v_2, ...], [v_1, v_2, ...], ...],
-
-        }
-        where n is the number of cells or grains. Note that the inner
-        list of vertices for each cell corresponds to the face vertices.
-        """
-
-        self._ensure_fitted()
-
-        return self._get_vertices(
-            pd=self.optimal_transport_.pd, space_dim=self.space_dim_
-        )
-
-    def get_weights(self) -> np.ndarray:
-        """
-        Get the weights of the laguerre diagram.
-        """
-
-        self._ensure_fitted()
-
-        return self.optimal_transport_.pd.get_weights()
-
-    def diagram_to_vtk(self, filename: str | Path) -> None:
-        """
-        Write the generated diagram to .vkt file; filename must ends with .vtk.
-        """
-
-        self._ensure_fitted()
-
-        self.optimal_transport_.pd.display_vtk(
-            filename=filename, points=False, centroids=False
-        )
-
-        return None
 
     def get_params(self) -> dict[str, Any]:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -2181,7 +2181,7 @@ wheels = [
 
 [[package]]
 name = "synthetmic"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "joblib" },

--- a/uv.lock
+++ b/uv.lock
@@ -406,6 +406,25 @@ wheels = [
 ]
 
 [[package]]
+name = "damask"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h5py" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pyyaml" },
+    { name = "scipy" },
+    { name = "vtk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/8f/f0f40c4d215db7851edb3f49749d94d1678dd4610d76ca15df6663429585/damask-3.0.2.tar.gz", hash = "sha256:47b748b848b80e421a261ae24b1fb66715ff08d465ef50d99b75d2a7b5b1347c", size = 108770, upload-time = "2025-06-09T19:58:46.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/6c/7a816889602e8db628be55209f409670b190d8cb62720445bc156de54d5f/damask-3.0.2-py3-none-any.whl", hash = "sha256:be1a4c8d199dca23b297675e39bb5ce7473953d6c23789bbd10bb2435a06c294", size = 122310, upload-time = "2025-06-09T19:58:44.825Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -558,6 +577,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/31/8fbc5af2d183bff20f21aa743b4088eac4445d2bb1cdece449ae80e4e2d1/frozenlist-1.7.0-cp313-cp313t-win32.whl", hash = "sha256:3a14027124ddb70dfcee5148979998066897e79f89f64b13328595c4bdf77c81", size = 43059, upload-time = "2025-06-09T23:02:02.072Z" },
     { url = "https://files.pythonhosted.org/packages/bb/ed/41956f52105b8dbc26e457c5705340c67c8cc2b79f394b79bffc09d0e938/frozenlist-1.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3bf8010d71d4507775f658e9823210b7427be36625b387221642725b515dcf3e", size = 47516, upload-time = "2025-06-09T23:02:03.779Z" },
     { url = "https://files.pythonhosted.org/packages/ee/45/b82e3c16be2182bff01179db177fe144d58b5dc787a7d4492c6ed8b9317f/frozenlist-1.7.0-py3-none-any.whl", hash = "sha256:9a5af342e34f7e97caf8c995864c7a396418ae2859cc6fdf1b1073020d516a7e", size = 13106, upload-time = "2025-06-09T23:02:34.204Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/95/a825894f3e45cbac7554c4e97314ce886b233a20033787eda755ca8fecc7/h5py-3.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:719439d14b83f74eeb080e9650a6c7aa6d0d9ea0ca7f804347b05fac6fbf18af", size = 3721663, upload-time = "2026-03-06T13:47:49.599Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3b/38ff88b347c3e346cda1d3fc1b65a7aa75d40632228d8b8a5d7b58508c24/h5py-3.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3f0a0e136f2e95dd0b67146abb6668af4f1a69c81ef8651a2d316e8e01de447", size = 3087630, upload-time = "2026-03-06T13:47:51.249Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a8/2594cef906aee761601eff842c7dc598bea2b394a3e1c00966832b8eeb7c/h5py-3.16.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a6fbc5367d4046801f9b7db9191b31895f22f1c6df1f9987d667854cac493538", size = 4823472, upload-time = "2026-03-06T13:47:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/c1f604538ff6db22a0690be2dc44ab59178e115f63c917794e529356ab23/h5py-3.16.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fb1720028d99040792bb2fb31facb8da44a6f29df7697e0b84f0d79aff2e9bd3", size = 5027150, upload-time = "2026-03-06T13:47:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fd/301739083c2fc4fd89950f9bcfce75d6e14b40b0ca3d40e48a8993d1722c/h5py-3.16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:314b6054fe0b1051c2b0cb2df5cbdab15622fb05e80f202e3b6a5eee0d6fe365", size = 4814544, upload-time = "2026-03-06T13:47:56.893Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/42/2193ed41ccee78baba8fcc0cff2c925b8b9ee3793305b23e1f22c20bf4c7/h5py-3.16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ffbab2fedd6581f6aa31cf1639ca2cb86e02779de525667892ebf4cc9fd26434", size = 5034013, upload-time = "2026-03-06T13:47:59.01Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/20/e6c0ff62ca2ad1a396a34f4380bafccaaf8791ff8fccf3d995a1fc12d417/h5py-3.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:17d1f1630f92ad74494a9a7392ab25982ce2b469fc62da6074c0ce48366a2999", size = 3191673, upload-time = "2026-03-06T13:48:00.626Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/48/239cbe352ac4f2b8243a8e620fa1a2034635f633731493a7ff1ed71e8658/h5py-3.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:85b9c49dd58dc44cf70af944784e2c2038b6f799665d0dcbbc812a26e0faa859", size = 2673834, upload-time = "2026-03-06T13:48:02.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3c/7fcd9b4c9eed82e91fb15568992561019ae7a829d1f696b2c844355d95dd/h5py-3.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9c9d307c0ef862d1cd5714f72ecfafe0a5d7529c44845afa8de9f46e5ba8bd65", size = 3678608, upload-time = "2026-03-06T13:48:35.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b7/9366ed44ced9b7ef357ab48c94205280276db9d7f064aa3012a97227e966/h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1eff849cdd53cbc73c214c30ebdb6f1bb8b64790b4b4fc36acdb5e43570210", size = 3054773, upload-time = "2026-03-06T13:48:37.139Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/4964bc0e91e86340c2bbda83420225b2f770dcf1eb8a39464871ad769436/h5py-3.16.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2c04d129f180019e216ee5f9c40b78a418634091c8782e1f723a6ca3658b965", size = 5198886, upload-time = "2026-03-06T13:48:38.879Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/16/d905e7f53e661ce2c24686c38048d8e2b750ffc4350009d41c4e6c6c9826/h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e4360f15875a532bc7b98196c7592ed4fc92672a57c0a621355961cafb17a6dd", size = 5404883, upload-time = "2026-03-06T13:48:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f2/58f34cb74af46d39f4cd18ea20909a8514960c5a3e5b92fd06a28161e0a8/h5py-3.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fae9197390c325e62e0a1aa977f2f62d994aa87aab182abbea85479b791197c", size = 5192039, upload-time = "2026-03-06T13:48:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ca/934a39c24ce2e2db017268c08da0537c20fa0be7e1549be3e977313fc8f5/h5py-3.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:43259303989ac8adacc9986695b31e35dba6fd1e297ff9c6a04b7da5542139cc", size = 5421526, upload-time = "2026-03-06T13:48:44.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/14/615a450205e1b56d16c6783f5ccd116cde05550faad70ae077c955654a75/h5py-3.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:fa48993a0b799737ba7fd21e2350fa0a60701e58180fae9f2de834bc39a147ab", size = 3183263, upload-time = "2026-03-06T13:48:47.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/48/a6faef5ed632cae0c65ac6b214a6614a0b510c3183532c521bdb0055e117/h5py-3.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:1897a771a7f40d05c262fc8f37376ec37873218544b70216872876c627640f63", size = 2663450, upload-time = "2026-03-06T13:48:48.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/32/0c8bb8aedb62c772cf7c1d427c7d1951477e8c2835f872bc0a13d1f85f86/h5py-3.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15922e485844f77c0b9d275396d435db3baa58292a9c2176a386e072e0cf2491", size = 3760693, upload-time = "2026-03-06T13:48:50.453Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1f/fcc5977d32d6387c5c9a694afee716a5e20658ac08b3ff24fdec79fb05f2/h5py-3.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:df02dd29bd247f98674634dfe41f89fd7c16ba3d7de8695ec958f58404a4e618", size = 3181305, upload-time = "2026-03-06T13:48:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a1/af87f64b9f986889884243643621ebbd4ac72472ba8ec8cec891ac8e2ca1/h5py-3.16.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0f456f556e4e2cebeebd9d66adf8dc321770a42593494a0b6f0af54a7567b242", size = 5074061, upload-time = "2026-03-06T13:48:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d0/146f5eaff3dc246a9c7f6e5e4f42bd45cc613bce16693bcd4d1f7c958bf5/h5py-3.16.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3e6cb3387c756de6a9492d601553dffea3fe11b5f22b443aac708c69f3f55e16", size = 5279216, upload-time = "2026-03-06T13:48:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/12a13424f1e604fc7df9497b73c0356fb78c2fb206abd7465ce47226e8fd/h5py-3.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8389e13a1fd745ad2856873e8187fd10268b2d9677877bb667b41aebd771d8b7", size = 5070068, upload-time = "2026-03-06T13:48:59.169Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
 ]
 
 [[package]]
@@ -2127,6 +2197,9 @@ dependencies = [
 cli = [
     { name = "click" },
 ]
+example = [
+    { name = "damask" },
+]
 tests = [
     { name = "joblib" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
@@ -2138,6 +2211,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.2.1" },
+    { name = "damask", marker = "extra == 'example'", specifier = "==3.0.2" },
     { name = "joblib", specifier = ">=1.5.3" },
     { name = "joblib", marker = "extra == 'tests'", specifier = ">=1.5.3" },
     { name = "matplotlib", specifier = ">=3.10.3" },
@@ -2150,7 +2224,7 @@ requires-dist = [
     { name = "tabulate", marker = "extra == 'tests'", specifier = ">=0.9.0" },
     { name = "vtk", specifier = ">=9.4.2" },
 ]
-provides-extras = ["cli", "examples", "tests"]
+provides-extras = ["cli", "examples", "tests", "example"]
 
 [[package]]
 name = "tabulate"


### PR DESCRIPTION
This pull request fixes the domain volume and target volume difference in `synthetmic.data.paper.create_example4b_data` function when `initializer='banded'`.

It also refactors the `synthetmic.generate.DiagramGenerator` base class to include methods common to all diagrams. 